### PR TITLE
:hammer: fix an error thrown by UglifyJs

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,4 @@
-function toBoolean(val) {
+export function toBoolean(val) {
   if (val === '') return val
   return val === 'true' || val == '1'
-}
-
-module.exports = {
-  toBoolean
 }


### PR DESCRIPTION
I'm using vue-qr in my project which is created from the vue-cli webpack template, running `npm run build` will throw the following error:
`ERROR in static/js/vendor.d513252f5d3a2d1eb2cb.js from UglifyJs
Unexpected token: punc (}) [./~/vue-qr/src/util.js:8,0][static/js/vendor.d513252f5d3a2d1eb2cb.js:28170,0]`
so I  updated util.js by using ES6 export instead of `module.exports` and the error is gone.
please kindly review my changes and let me know if there are any further changes required.