### PR TITLE
:bug: fix: QR not generated properly in wechat built-in browser

### DIFF
--- a/src/vue-qr.js
+++ b/src/vue-qr.js
@@ -47,29 +47,33 @@ export default {
       if (this.bgSrc && this.logoSrc) {
         const bgImg = new Image()
         const logoImg = new Image()
-        bgImg.src = this.bgSrc
         bgImg.onload = function() {
-          logoImg.src = that.logoSrc
           logoImg.onload = function() {
             that.render(bgImg, logoImg)
           }
+          logoImg.crossOrigin = 'anonymous'
+          logoImg.src = that.logoSrc
         }
+        bgImg.crossOrigin = 'anonymous'
+        bgImg.src = this.bgSrc
         return
       }
       if (this.bgSrc) {
         const img = new Image()
-        img.src = this.bgSrc
         img.onload = function() {
           that.render(img)
         }
+        img.crossOrigin = 'anonymous'
+        img.src = this.bgSrc
         return
       }
       if (this.logoSrc) {
         const img = new Image()
-        img.src = this.logoSrc
         img.onload = function() {
           that.render(undefined, img)
         }
+        img.crossOrigin = 'anonymous'
+        img.src = this.logoSrc
         return
       }
       that.render()


### PR DESCRIPTION
Everything works fine except the QR will not generated properly in WeChat built-in browser if logoSrc and/or bgSrc are from external resources.
After enabled CORS loading for the Image, the issue is fixed.
For more details, refer to [Awesome-qr Issue#8](https://github.com/SumiMakito/Awesome-qr.js/issues/8)