### PR TITLE
:bug: props fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ autoColor | If set to true, the dominant color of backgroundImage will be used a
 binarize | If set to true, the whole image will be binarized with the given threshold, or default threshold if not specified. Default is false. 若为 true, 图像将被二值化处理, 未指定阈值则使用默认值
 binarizeThreshold | Threshold used to binarize the whole image. Default is 128. (0 < threshold < 255) 二值化处理的阈值
 callback | Data URI of the generated QR code will be available here. 生成的二维码 Data URI 可以在回调中取得
+bindElement | If set to true, the generated QR will bind to a HTML element automatically. Default is TRUE. 指定是否需要自动将生成的二维码绑定到HTML上, 默认是TRUE
 
 
 

--- a/src/vue-qr.js
+++ b/src/vue-qr.js
@@ -2,25 +2,82 @@ const uuidv4 = require('uuid/v4')
 import { toBoolean } from './util.js'
 import AwesomeQRCode from 'awesome-qr'
 export default {
-  props: [
-    'text',
-    'size',
-    'margin',
-    'colorDark',
-    'colorLight',
-    'bgSrc',
-    'backgroundDimming',
-    'logoSrc',
-    'logoScale',
-    'logoMargin',
-    'logoCornerRadius',
-    'whiteMargin',
-    'dotScale',
-    'autoColor',
-    'binarize',
-    'binarizeThreshold',
-    'callback'
-  ],
+  props: {
+    text: {
+      type: String,
+      required: true
+    },
+    size: {
+      type: Number,
+      default: 200
+    },
+    margin: {
+      type: Number,
+      default: 20
+    },
+    colorDark: {
+      type: String,
+      default: '#000000'
+    },
+    colorLight: {
+      type: String,
+      default: '#FFFFFF'
+    },
+    bgSrc: {
+      type: String,
+      default: undefined
+    },
+    backgroundDimming: {
+      type: String,
+      default: 'rgba(0,0,0,0)'
+    },
+    logoSrc: {
+      type: String,
+      default: undefined
+    },
+    logoScale: {
+      type: Number,
+      default: 0.2
+    },
+    logoMargin: {
+      type: Number,
+      default: 0
+    },
+    logoCornerRadius: {
+      type: Number,
+      default: 8
+    },
+    whiteMargin: {
+      type: [Boolean, String],
+      default: true
+    },
+    dotScale: {
+      type: Number,
+      default: 0.35
+    },
+    autoColor: {
+      type: [Boolean, String],
+      default: true
+    },
+    binarize: {
+      type: [Boolean, String],
+      default: false
+    },
+    binarizeThreshold: {
+      type: Number,
+      default: 128
+    },
+    callback: {
+      type: Function,
+      default: function () {
+        return undefined
+      }
+    },
+    bindElement: {
+      type: Boolean,
+      default: true
+    }
+  },
   name: 'vue-qr',
   data() {
     return {
@@ -82,25 +139,25 @@ export default {
       const that = this
       new AwesomeQRCode().create({
         text: that.text,
-        size: that.size || 200,
-        margin: that.margin || 20,
-        colorDark: that.colorDark || '#000000',
-        colorLight: that.colorLight || '#FFFFFF',
+        size: that.size,
+        margin: that.margin,
+        colorDark: that.colorDark,
+        colorLight: that.colorLight,
         backgroundImage: img,
-        backgroundDimming: that.backgroundDimming || 'rgba(0,0,0,0)',
+        backgroundDimming: that.backgroundDimming,
         logoImage: logoImg,
-        logoScale: that.logoScale || 0.2,
-        logoMargin: that.logoMargin || 0,
-        logoCornerRadius: that.logoCornerRadius || 8,
-        whiteMargin: toBoolean(that.whiteMargin) || true,
-        dotScale: that.dotScale || 0.35,
-        autoColor: toBoolean(that.autoColor) || true,
-        binarize: toBoolean(that.binarize) || false,
-        binarizeThreshold: that.binarizeThreshold || 128,
+        logoScale: that.logoScale,
+        logoMargin: that.logoMargin,
+        logoCornerRadius: that.logoCornerRadius,
+        whiteMargin: toBoolean(that.whiteMargin),
+        dotScale: that.dotScale,
+        autoColor: toBoolean(that.autoColor),
+        binarize: toBoolean(that.binarize),
+        binarizeThreshold: that.binarizeThreshold,
         callback: function(dataURI) {
           that.callback && that.callback(dataURI)
         },
-        bindElement: that.uuid
+        bindElement: that.bindElement ? that.uuid : undefined
       })
     }
   }

--- a/src/vue-qr.vue
+++ b/src/vue-qr.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="bindElement">
     <img v-bind="{id:uuid}">
   </div>
 </template>


### PR DESCRIPTION
This PR addresses the following issues:
1. prop `autoColor` and `whiteMargin` are always `TRUE` and it's caused by the following code in `vue-qr.js`:
`autoColor: toBoolean(that.autoColor) || true`
`whiteMargin: toBoolean(that.whiteMargin) || true`
2. prop `logoCornerRadius` not working with number value `0` while it's working when using string value `0` due to the code:
`logoCornerRadius: that.logoCornerRadius || 8`
3. In `awesome-qr`, the `bindElement` is optional. It provides the ability to not bind to any HTML node and only return the dataURI generated for further processing. However, `vue-qr` always binds the generated QR image data to a HTML node and it's not so handy in some scenarios.

To adress issue 1 and issue 2, I moved the default value for each prop to props definition and added validations for them. And for backward compatibility, `String` value is also allowed for `whiteMargin`, `autoColor` and `binarize`.
To address issue 3, I added a new prop named `bindElement` which accepts `Boolean` value with default value `TRUE`.


Regards,