### PR TITLE
:ambulance: use awesome-qr < v1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "node build/build.js"
   },
   "dependencies": {
-    "awesome-qr": "^1.0.8",
+    "awesome-qr": "~1.0.8",
     "uuid": "^3.1.0",
     "vue": "^2.2.6"
   },


### PR DESCRIPTION
This PR fixes build failure caused by `Awesome-qr.is`:
1. The latest version of [Awesome-qr.is](https://github.com/SumiMakito/Awesome-qr.js) 1.2.0. From this version, it introduces [node-canvas](https://github.com/Automattic/node-canvas) as its dependency for Node.js environment usage and the main entry for NPM package has been changed to `awesome-qr-node.js` which only supports Node.js APIs. When working with webpack, This breaking change causes webpack trying to load the native modules for `node-canvas`. However, this will never work because we are in browser environment. So we should keep using Awesome-qr.is lower than v1.2.0 until there is a browser entry in its `package.json`.
2. Why not Awesome-qr.is 1.1.0? 
  Awesome-qr.is 1.1.0 introduces a new option named `gifBackground` and 3 more js files to support GIF background image. Since vue-qr hasn't support GIF background image yet, I figured not using Awesome-qr.is 1.1.0 is the best choice here as it will keep the output js files as minimal as possible for production build.
BTW, there is a typo in my commit message. `user` should be `use`😅